### PR TITLE
Removed 'Session' from "Session placed/destroyed" HUD

### DIFF
--- a/src/main/kotlin/trombone/Statistics.kt
+++ b/src/main/kotlin/trombone/Statistics.kt
@@ -163,7 +163,7 @@ object Statistics {
         if (!anonymizeStats) displayText.add("    Start:", primaryColor)
         if (!anonymizeStats) displayText.addLine("(${startingBlockPos.asString()})", secondaryColor)
 
-        displayText.add("    Session placed / destroyed:", primaryColor)
+        displayText.add("    Placed / destroyed:", primaryColor)
         displayText.addLine("%,d".format(totalBlocksPlaced) + " / " + "%,d".format(totalBlocksBroken), secondaryColor)
 
 


### PR DESCRIPTION
The HUD section it's contained within is labelled Session, so I feel it's unnecessary to include it in this stats line.